### PR TITLE
add update-nixpkgs tooling

### DIFF
--- a/.github/workflows/update-nixpkgs.yaml
+++ b/.github/workflows/update-nixpkgs.yaml
@@ -1,0 +1,53 @@
+name: update-nixpkgs
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "5 3 * * *"
+
+jobs:
+  run-nixpkgs-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: 'release-tools'
+      - uses: cachix/install-nix-action@v21
+        with:
+          # Nix 2.24 breaks flake update
+          install_url: https://releases.nixos.org/nix/nix-2.18.9/install
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_UPDATE_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_UPDATE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - run: |
+          echo "::add-mask::${{steps.app-token.outputs.token}}"
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+      - uses: actions/checkout@v4
+        with:
+          repository: flyingcircusio/fc-nixos
+          path: 'fc-nixos'
+          token: ${{ steps.app-token.outputs.token }}
+          # fetch all branches and tags
+          fetch-depth: 0
+      - name: build release tooling
+        run: |
+          nix build ./release-tools#
+      - run: |
+          ./result/bin/update-nixpkgs update \
+            --fc-nixos-dir fc-nixos \
+            --nixpkgs-dir nixpkgs \
+            --nixpkgs-upstream-url https://github.com/NixOS/nixpkgs \
+            --nixpkgs-origin-url https://x-access-token:${{steps.app-token.outputs.token}}@github.com/flyingcircusio/nixpkgs.git \
+            --platform-versions 24.05
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
           build-system = [ pypkgs.setuptools-scm ];
           dependencies = [
             pypkgs.setuptools
+            pypkgs.gitpython
+            pypkgs.pygithub
             pkgs.scriv
             pkgs.gh
           ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dynamic = ["version"]
 requires-python = ">= 3.10"
 dependencies = [
     "scriv==1.5.1",
+    "pygithub~=2",
+    "gitpython~=3"
 ]
 
 [project.scripts]
 fc-release = "release.fc_release:main"
+update-nixpkgs = "update_nixpkgs:main"

--- a/src/update_nixpkgs/__init__.py
+++ b/src/update_nixpkgs/__init__.py
@@ -1,0 +1,86 @@
+import argparse
+import os
+import sys
+from logging import INFO, basicConfig
+
+FC_NIXOS_REPO = "flyingcircusio/fc-nixos"
+NIXPKGS_REPO = "flyingcircusio/nixpkgs"
+
+
+def main():
+    import update_nixpkgs.cleanup
+    import update_nixpkgs.update
+
+    basicConfig(level=INFO)
+    try:
+        github_access_token = os.environ["GH_TOKEN"]
+    except KeyError:
+        raise Exception("Missing `GH_TOKEN` environment variable.")
+
+    parser = argparse.ArgumentParser("nixpkgs updater for fc-nixos")
+    parser.set_defaults(func="print_usage")
+    subparsers = parser.add_subparsers()
+
+    parser_update = subparsers.add_parser(
+        "update", help="run nixpkgs update workflow"
+    )
+    parser_update.add_argument(
+        "--fc-nixos-dir",
+        help="Directory where the fc-nixos git checkout is in",
+        required=True,
+    )
+    parser_update.add_argument(
+        "--nixpkgs-dir",
+        help="Directory where the nixpkgs git checkout is in",
+        required=True,
+    )
+    parser_update.add_argument(
+        "--nixpkgs-upstream-url",
+        help="URL to the upstream nixpkgs repository",
+        required=True,
+    )
+    parser_update.add_argument(
+        "--nixpkgs-origin-url",
+        help="URL to push the nixpkgs updates to",
+        required=True,
+    )
+    parser_update.add_argument(
+        "--platform-versions",
+        help="Platform versions",
+        required=True,
+        nargs="+",
+    )
+    parser_update.set_defaults(func=update_nixpkgs.update.run)
+
+    parser_cleanup = subparsers.add_parser(
+        "cleanup", help="run nixpkgs update cleanup"
+    )
+    parser_cleanup.add_argument(
+        "--merged-pr-id", help="merged fc-nixos PR ID", required=True
+    )
+    parser_cleanup.add_argument(
+        "--nixpkgs-dir",
+        help="Directory where the nixpkgs git checkout is in",
+        required=True,
+    )
+    parser_cleanup.add_argument(
+        "--nixpkgs-origin-url",
+        help="URL to push the nixpkgs updates to",
+        required=True,
+    )
+    parser_cleanup.set_defaults(func=update_nixpkgs.cleanup.run)
+
+    args = parser.parse_args()
+    func = args.func
+    if func == "print_usage":
+        parser.print_usage()
+        sys.exit(1)
+
+    kwargs = dict(args._get_kwargs())
+    del kwargs["func"]
+    kwargs["github_access_token"] = github_access_token
+    func(**kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/update_nixpkgs/cleanup.py
+++ b/src/update_nixpkgs/cleanup.py
@@ -1,0 +1,127 @@
+"""
+This script should be run when an automatic update-nixpkgs PR has been merged.
+It will merge the corresponding flyingcircus/nixpkgs PR and cleanup
+all old fc-nixos and nixpkgs PRs/branches that haven't been merged.
+"""
+
+import datetime
+import os
+from dataclasses import dataclass
+from logging import info, warning
+
+from git import GitCommandError, Repo
+from github import Auth, Github
+
+from update_nixpkgs import FC_NIXOS_REPO, NIXPKGS_REPO
+
+
+@dataclass
+class Remote:
+    url: str
+    branches: list[str]
+
+
+def nixpkgs_repository(directory: str, remotes: dict[str, Remote]) -> Repo:
+    info("Updating nixpkgs repository.")
+    if os.path.exists(directory):
+        repo = Repo(directory)
+    else:
+        repo = Repo.init(directory, mkdir=True)
+
+    for name, remote in remotes.items():
+        info(f"Updating nixpkgs repository remote `{name}`.")
+        if name in repo.remotes and repo.remotes[name].url != remote.url:
+            repo.delete_remote(repo.remote(name))
+        if name not in repo.remotes:
+            repo.create_remote(name, remote.url)
+
+        for branch in remote.branches:
+            info(
+                f"Fetching nixpkgs repository remote `{name}` - branch `{branch}`."
+            )
+            getattr(repo.remotes, name).fetch(
+                refspec=branch, filter="blob:none"
+            )
+
+    return repo
+
+
+def rebase_nixpkgs(
+    gh: Github, nixpkgs_repo: Repo, target_branch: str, integration_branch: str
+) -> bool:
+    """Rebase nixpkgs repo integration branch onto target branch
+    Returns: True when successful, False when unsuccessful.
+    """
+    info("Rebase nixpkgs repo integration branch onto target branch.")
+    if nixpkgs_repo.is_dirty():
+        raise Exception("Repository is dirty!")
+
+    nixpkgs_repo.git.checkout(target_branch)
+
+    try:
+        nixpkgs_repo.git.rebase(f"origin/{integration_branch}")
+    except GitCommandError as e:
+        warning(f"Rebase failed:\n{e.stderr}")
+        nixpkgs_repo.git.rebase(abort=True)
+        warning("Aborted rebase.")
+        return False
+
+    nixpkgs_repo.git.push(force_with_lease=True)
+    # Tag result so that the commit is always referenced so that other release tooling can find it.
+    nixpkgs_repo.git.tag(integration_branch, message=integration_branch)
+    nixpkgs_repo.git.push("origin", tags=True)
+    gh.get_repo(NIXPKGS_REPO).get_git_ref(
+        f"heads/{integration_branch}"
+    ).delete()
+    return True
+
+
+def cleanup_old_prs_and_branches(gh: Github, merged_integration_branch: str):
+    info("Cleaning up old PRs and branches.")
+    fc_nixos_repo = gh.get_repo(FC_NIXOS_REPO)
+    nixpkgs_repo = gh.get_repo(NIXPKGS_REPO)
+    merged_integration_branch_date = datetime.date.fromisoformat(
+        merged_integration_branch.split("/")[2]
+    )
+    # branches will be closed automatically by GitHub, when the branch is deleted
+    for repo in [fc_nixos_repo, nixpkgs_repo]:
+        for branch in repo.get_branches():
+            if not branch.name.startswith("nixpkgs-auto-update/"):
+                continue
+            branch_datestr = branch.name.split("/")[2]
+            if (
+                datetime.date.fromisoformat(branch_datestr)
+                < merged_integration_branch_date
+            ):
+                repo.get_git_ref(f"heads/{branch.name}").delete()
+
+
+def run(
+    merged_pr_id: str,
+    nixpkgs_origin_url: str,
+    nixpkgs_dir: str,
+    github_access_token: str,
+):
+    gh = Github(auth=Auth.Token(github_access_token))
+    fc_nixos_pr = gh.get_repo(FC_NIXOS_REPO).get_pull(int(merged_pr_id))
+    pr_platform_version = fc_nixos_pr.base.ref.split("-")[1]
+    integration_branch = fc_nixos_pr.head.ref
+    nixpkgs_target_branch = f"nixos-{pr_platform_version}"
+
+    remotes = {
+        "origin": Remote(
+            nixpkgs_origin_url,
+            [integration_branch, nixpkgs_target_branch],
+        )
+    }
+    nixpkgs_repo = nixpkgs_repository(nixpkgs_dir, remotes)
+    if rebase_nixpkgs(
+        gh,
+        nixpkgs_repo,
+        nixpkgs_target_branch,
+        integration_branch,
+    ):
+        fc_nixos_pr.create_issue_comment(
+            f"Rebased nixpkgs `{nixpkgs_target_branch}` branch successfully."
+        )
+        cleanup_old_prs_and_branches(gh, integration_branch)

--- a/src/update_nixpkgs/update.py
+++ b/src/update_nixpkgs/update.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+"""
+Workflow:
+* get executed in a given interval (e.g. daily - channel bumps are happening approximately every other day)
+* pull all given releases into fc fork (rebase strategy)
+    * post error on merge conflict
+* if new:
+    * push to integration branch (nixpkgs-auto-update/fc-XX.XX-dev/YYYY-MM-DD)
+    * update fc-nixos & create PR
+    * comment diff/changelog since last commit into PR
+On Merge (fc-nixos):
+    * merge updated nixpkgs into nixos-XX.XX branch
+    * delete old integration branches in nixpkgs and fc-nixos
+
+Manual merges work by pushing manually in the nixpkgs integration branch and running the GHA manually.
+
+"""
+import datetime
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from os import path
+from pathlib import Path
+from subprocess import check_output
+
+from git import Commit, Repo
+from git.exc import GitCommandError
+from github import Auth, Github
+
+from update_nixpkgs import FC_NIXOS_REPO, NIXPKGS_REPO
+
+NIXOS_VERSION_PATH = "release/nixos-version"
+PACKAGE_VERSIONS_PATH = "release/package-versions.json"
+VERSIONS_PATH = "release/versions.json"
+CHANGELOG_DIR = "changelog.d"
+
+
+@dataclass
+class NixpkgsRebaseResult:
+    upstream_commit: Commit
+
+    # This is the latest commit on the release branch in our fork.
+    # If we have multiple consecutive updates, it is not the same as
+    # fork_before_rebase since this is the state of the tracking branch before
+    # the last rebase. This commit is important to generate the full
+    # changelog.
+    fork_commit: Commit
+    fork_before_rebase: Commit
+    fork_after_rebase: Commit
+
+
+@dataclass
+class Remote:
+    url: str
+    branches: list[str]
+
+
+def nixpkgs_repository(directory: str, remotes: dict[str, Remote]) -> Repo:
+    logging.info("Updating nixpkgs repository.")
+    if path.exists(directory):
+        repo = Repo(directory)
+    else:
+        repo = Repo.init(directory, mkdir=True)
+
+    for name, remote in remotes.items():
+        logging.info(f"Updating nixpkgs repository remote `{name}`.")
+        if name in repo.remotes and repo.remotes[name].url != remote.url:
+            repo.delete_remote(repo.remote(name))
+        if name not in repo.remotes:
+            repo.create_remote(name, remote.url)
+
+        for branch in remote.branches:
+            logging.info(
+                f"Fetching nixpkgs repository remote `{name}` - branch `{branch}`."
+            )
+            # Ignore errors. This is intended as the last day integration branch may not exist
+            try:
+                getattr(repo.remotes, name).fetch(
+                    refspec=branch, filter="blob:none"
+                )
+            except GitCommandError as e:
+                logging.debug("Error while fetching branch ", e)
+                pass
+
+    return repo
+
+
+def rebase_nixpkgs(
+    nixpkgs_repo: Repo,
+    branch_to_rebase: str,
+    integration_branch: str,
+    last_day_integration_branch: str,
+) -> NixpkgsRebaseResult | None:
+    logging.info("Trying to rebase nixpkgs repository.")
+    if nixpkgs_repo.is_dirty():
+        raise Exception("Repository is dirty!")
+
+    if not any(integration_branch == head.name for head in nixpkgs_repo.heads):
+        tracking_branch = nixpkgs_repo.create_head(
+            integration_branch, f"origin/{branch_to_rebase}"
+        )
+        tracking_branch.checkout()
+    else:
+        nixpkgs_repo.git.checkout(integration_branch)
+
+    latest_upstream = nixpkgs_repo.refs[f"upstream/{branch_to_rebase}"].commit
+    common_grounds = nixpkgs_repo.merge_base(
+        f"upstream/{branch_to_rebase}", "HEAD"
+    )
+
+    if all(
+        latest_upstream.hexsha != commit.hexsha for commit in common_grounds
+    ):
+        logging.info(
+            f"Latest commit of {branch_to_rebase} is '{latest_upstream.hexsha}' which is not part of our fork, rebasing."
+        )
+        current_state = nixpkgs_repo.head.commit
+        try:
+            nixpkgs_repo.git.rebase(f"upstream/{branch_to_rebase}")
+        except GitCommandError:
+            logging.exception("nixpkgs rebase failed")
+            sys.exit(1)
+
+        # Check if there are new commits compared to the last day's integration branch.
+        if f"origin/{last_day_integration_branch}" in nixpkgs_repo.refs:
+            diff_index = nixpkgs_repo.git.diff_index(
+                f"origin/{last_day_integration_branch}"
+            )
+
+            if diff_index == "":
+                logging.info(
+                    "No changes compared to the last day's integration branch. Not creating a new PR."
+                )
+                return None
+
+        nixpkgs_repo.git.push("origin", integration_branch, force=True)
+
+        return NixpkgsRebaseResult(
+            upstream_commit=latest_upstream,
+            fork_commit=nixpkgs_repo.refs[f"origin/{branch_to_rebase}"].commit,
+            fork_before_rebase=current_state,
+            fork_after_rebase=nixpkgs_repo.head.commit,
+        )
+
+    logging.info("Nothing to do.")
+
+
+def update_fc_nixos(
+    fc_nixos_dir: str,
+    target_branch: str,
+    integration_branch: str,
+    previous_hex_sha: str,
+    new_hex_sha: str,
+):
+    logging.info("Update fc-nixos.")
+    original_workdir = Path.cwd()
+    os.chdir(original_workdir / fc_nixos_dir)
+    repo = Repo(Path.cwd())
+    if not any(integration_branch == head.name for head in repo.heads):
+        tracking_branch = repo.create_head(
+            integration_branch, f"origin/{target_branch}"
+        )
+        tracking_branch.checkout()
+    else:
+        repo.git.checkout(integration_branch)
+
+    check_output(
+        [
+            "nix",
+            "flake",
+            "lock",
+            "--override-input",
+            "nixpkgs",
+            f"github:{NIXPKGS_REPO}/{new_hex_sha}",
+        ]
+    )
+    check_output(["nix", "run", ".#buildVersionsJson"]).decode("utf-8")
+    check_output(["nix", "run", ".#buildPackageVersionsJson"]).decode("utf-8")
+
+    changelog_path = (
+        Path(CHANGELOG_DIR)
+        / f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}_nixpkgs-auto-update-{target_branch}.md"
+    )
+    changelog_path.write_text(
+        f"""
+### NixOS XX.XX platform
+
+- Update nixpkgs from {previous_hex_sha} to {new_hex_sha}
+"""
+    )
+
+    repo.git.add(
+        [
+            "flake.lock",
+            VERSIONS_PATH,
+            PACKAGE_VERSIONS_PATH,
+            str(changelog_path),
+        ]
+    )
+    repo.git.commit(message=f"Auto update nixpkgs to {new_hex_sha}")
+    repo.git.push("origin", integration_branch, force=True)
+    os.chdir(original_workdir)
+
+
+def create_fc_nixos_pr(
+    platform_version: str,
+    target_branch: str,
+    integration_branch: str,
+    github_access_token: str,
+    now: str,
+):
+    logging.info("Create PR in fc-nixos.")
+    gh = Github(auth=Auth.Token(github_access_token))
+    fc_nixos_repo = gh.get_repo(FC_NIXOS_REPO)
+    # XXX: Currently deactivated, as there is a bug in the GH REST API so that no result is returned
+    # If there is an open PR for this integration branch, don't create a new one.
+    # if fc_nixos_repo.get_pulls(base=target_branch,head=f"flyingcircusio:{integration_branch}", state="open").totalCount > 0:
+    #     return
+    fc_nixos_repo.create_pull(
+        base=target_branch,
+        head=integration_branch,
+        title=f"[{platform_version}] Automated nixpkgs update {now}",
+        body=f"""\
+@flyingcircusio/release-managers
+
+View nixpkgs update branch: [{integration_branch}](https://github.com/{NIXPKGS_REPO}/tree/{integration_branch})
+
+Review Checklist:
+
+- [ ] Hydra is green
+- [ ] Package update versions look reasonable
+
+When manual changes are required: Push to the nixpkgs update branch, and run [the GitHub Action](https://github.com/flyingcircusio/fc-nixos-release-tools/actions/workflows/update-nixpkgs.yaml) manually.
+""",
+    )
+
+
+def run(
+    platform_versions: list[str],
+    nixpkgs_upstream_url: str,
+    nixpkgs_origin_url: str,
+    fc_nixos_dir: str,
+    nixpkgs_dir: str,
+    github_access_token: str,
+):
+    today = datetime.date.today().isoformat()
+    yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+
+    for platform_version in platform_versions:
+        logging.info(f"Updating platform {platform_version}")
+        nixpkgs_target_branch = f"nixos-{platform_version}"
+        fc_nixos_target_branch = f"fc-{platform_version}-dev"
+        integration_branch = (
+            f"nixpkgs-auto-update/{fc_nixos_target_branch}/{today}"
+        )
+        last_day_integration_branch = (
+            f"nixpkgs-auto-update/{fc_nixos_target_branch}/{yesterday}"
+        )
+
+        remotes = {
+            "upstream": Remote(nixpkgs_upstream_url, [nixpkgs_target_branch]),
+            "origin": Remote(
+                nixpkgs_origin_url,
+                [nixpkgs_target_branch, last_day_integration_branch],
+            ),
+        }
+        nixpkgs_repo = nixpkgs_repository(nixpkgs_dir, remotes)
+        if result := rebase_nixpkgs(
+            nixpkgs_repo,
+            nixpkgs_target_branch,
+            integration_branch,
+            last_day_integration_branch,
+        ):
+            logging.info(
+                f"Updated 'nixpkgs' to '{result.fork_after_rebase.hexsha}'"
+            )
+            update_fc_nixos(
+                fc_nixos_dir,
+                fc_nixos_target_branch,
+                integration_branch,
+                result.fork_commit.hexsha,
+                result.fork_after_rebase.hexsha,
+            )
+            create_fc_nixos_pr(
+                platform_version,
+                fc_nixos_target_branch,
+                integration_branch,
+                github_access_token,
+                today,
+            )


### PR DESCRIPTION
PL-133100

Successor of https://github.com/flyingcircusio/fc-nixos/pull/1173

Primary nixpkgs-update tooling. Also has a PR ([#1186](https://github.com/flyingcircusio/fc-nixos/pull/1186)) in fc-nixos with the cleanup GitHub Action.

Tested in fc-nixos-testing, fc-nixos-release-tools-testing:
* Action run: https://github.com/flyingcircusio/fc-nixos-release-tools-testing/actions/runs/12161271356
* Created PR: https://github.com/flyingcircusio/fc-nixos-testing/pull/27

Notifications to the Matrix channel in case of failures (e.g. rebase) will come in a later PR.