### PR TITLE
update-nixpkgs: do hard reset instead of merge and send matrix notifications

### DIFF
--- a/.github/workflows/update-nixpkgs.yaml
+++ b/.github/workflows/update-nixpkgs.yaml
@@ -51,3 +51,4 @@ jobs:
             --platform-versions 24.11 ${{ github.event_name == 'workflow_dispatch' && '--force' || '' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MATRIX_HOOKSHOT_URL: ${{ secrets.MATRIX_HOOKSHOT_URL }}

--- a/src/update_nixpkgs/__init__.py
+++ b/src/update_nixpkgs/__init__.py
@@ -16,6 +16,10 @@ def main():
         github_access_token = os.environ["GH_TOKEN"]
     except KeyError:
         raise Exception("Missing `GH_TOKEN` environment variable.")
+    try:
+        matrix_hookshot_url = os.environ["MATRIX_HOOKSHOT_URL"]
+    except KeyError:
+        raise Exception("Missing `MATRIX_HOOKSHOT_URL` environment variable.")
 
     parser = argparse.ArgumentParser("nixpkgs updater for fc-nixos")
     parser.set_defaults(func="print_usage")
@@ -65,6 +69,11 @@ def main():
         "--merged-pr-id", help="merged fc-nixos PR ID", required=True
     )
     parser_cleanup.add_argument(
+        "--fc-nixos-dir",
+        help="Directory where the fc-nixos git checkout is in",
+        required=True,
+    )
+    parser_cleanup.add_argument(
         "--nixpkgs-dir",
         help="Directory where the nixpkgs git checkout is in",
         required=True,
@@ -85,6 +94,7 @@ def main():
     kwargs = dict(args._get_kwargs())
     del kwargs["func"]
     kwargs["github_access_token"] = github_access_token
+    kwargs["matrix_hookshot_url"] = matrix_hookshot_url
     func(**kwargs)
 
 

--- a/src/update_nixpkgs/cleanup.py
+++ b/src/update_nixpkgs/cleanup.py
@@ -5,14 +5,19 @@ all old fc-nixos and nixpkgs PRs/branches that haven't been merged.
 """
 
 import datetime
+import json
+import logging
 import os
 from dataclasses import dataclass
 from logging import info, warning
+from pathlib import Path
 
 from git import GitCommandError, Repo
 from github import Auth, Github
+from github.PullRequest import PullRequest
 
 from update_nixpkgs import FC_NIXOS_REPO, NIXPKGS_REPO
+from utils.matrix import MatrixHookshot
 
 
 @dataclass
@@ -46,25 +51,47 @@ def nixpkgs_repository(directory: str, remotes: dict[str, Remote]) -> Repo:
     return repo
 
 
-def rebase_nixpkgs(
+def check_nixpkgs_up_to_date(nixpkgs_repo: Repo, fc_nixos_dir: str,  fc_nixos_target_branch: str, nixpkgs_target_branch: str, integration_branch: str, fc_nixos_pr: PullRequest, matrix_hookshot: MatrixHookshot):
+    fc_nixos_repo = Repo(fc_nixos_dir)
+    versions_json_path = Path(fc_nixos_dir) / "release" / "versions.json"
+
+    # HEAD = the head of the merged PR (before merge)
+    # XXX: This makes an assumption that the PR only contains 1 commit. This should be cleaned up.
+    merge_base = fc_nixos_repo.git.rev_parse("HEAD^")
+    # The integration branch is directly branched of the target branch, so we can only have one merge base.
+    fc_nixos_repo.git.switch(merge_base, detach=True)
+
+    with open(versions_json_path) as f:
+        versions = json.load(f)
+    previous_versions_rev = versions["nixpkgs"]["rev"]
+
+    current_fc_nixos_commit = nixpkgs_repo.refs[f"origin/{nixpkgs_target_branch}"].commit
+    result = current_fc_nixos_commit.hexsha == previous_versions_rev
+    if not result:
+        notification = f"""ERROR Unable to promote nixpkgs daily integration branch `{integration_branch}` to `{nixpkgs_target_branch}`.
+Integration branch not up to date. Expected commit `{previous_versions_rev}` as HEAD commit of `flyingcircusio/nixpkgs/{nixpkgs_target_branch}`, but got `{current_fc_nixos_commit.hexsha}`. 
+
+Please resolve manually by looking at the changes in nixpkgs between these commits, and then run [the GitHub Action](https://github.com/flyingcircusio/fc-nixos-release-tools/actions/workflows/update-nixpkgs.yaml) manually."""
+        fc_nixos_pr.create_issue_comment(notification)
+        matrix_hookshot.send_notification(f"update-nixpkgs PR [#{fc_nixos_pr.number}](https://github.com/flyingcircusio/fc-nixos/pull/{fc_nixos_pr.number}): {notification}")
+        logging.info(f"Expected commit `{previous_versions_rev}` as HEAD commit of `flyingcircusio/nixpkgs/{nixpkgs_target_branch}`, but got `{current_fc_nixos_commit.hexsha}`")
+    return result
+
+def promote_nixpkgs(
     gh: Github, nixpkgs_repo: Repo, target_branch: str, integration_branch: str
 ) -> bool:
-    """Rebase nixpkgs repo integration branch onto target branch
+    """Promote nixpkgs repo target branch (e.g. nixos-24.05) to the integration branch
+    via a hard reset.
+    First, check that the previous versions.json in fc-nixos is equivalent to the
     Returns: True when successful, False when unsuccessful.
     """
-    info("Rebase nixpkgs repo integration branch onto target branch.")
+    info("Hard reset nixpkgs target branch to integration branch.")
     if nixpkgs_repo.is_dirty():
         raise Exception("Repository is dirty!")
 
     nixpkgs_repo.git.checkout(target_branch)
 
-    try:
-        nixpkgs_repo.git.rebase(f"origin/{integration_branch}")
-    except GitCommandError as e:
-        warning(f"Rebase failed:\n{e.stderr}")
-        nixpkgs_repo.git.rebase(abort=True)
-        warning("Aborted rebase.")
-        return False
+    nixpkgs_repo.git.reset(f"origin/{integration_branch}", hard=True)
 
     nixpkgs_repo.git.push(force_with_lease=True)
     # Tag result so that the commit is always referenced so that other release tooling can find it.
@@ -104,13 +131,16 @@ def run(
     merged_pr_id: str,
     nixpkgs_origin_url: str,
     nixpkgs_dir: str,
+    fc_nixos_dir: str,
     github_access_token: str,
+    matrix_hookshot_url: str
 ):
     gh = Github(auth=Auth.Token(github_access_token))
     fc_nixos_pr = gh.get_repo(FC_NIXOS_REPO).get_pull(int(merged_pr_id))
     pr_platform_version = fc_nixos_pr.base.ref.split("-")[1]
     integration_branch = fc_nixos_pr.head.ref
     nixpkgs_target_branch = f"nixos-{pr_platform_version}"
+    matrix_hookshot = MatrixHookshot(matrix_hookshot_url)
 
     remotes = {
         "origin": Remote(
@@ -118,15 +148,14 @@ def run(
             [integration_branch, nixpkgs_target_branch],
         )
     }
+
     nixpkgs_repo = nixpkgs_repository(nixpkgs_dir, remotes)
-    if rebase_nixpkgs(
-        gh,
-        nixpkgs_repo,
-        nixpkgs_target_branch,
-        integration_branch,
-    ):
+    if not check_nixpkgs_up_to_date(nixpkgs_repo, fc_nixos_dir, fc_nixos_pr.base.ref, nixpkgs_target_branch, integration_branch, fc_nixos_pr, matrix_hookshot):
+        logging.error("Abort promotion of nixpkgs branch. PR is not up to date.")
+        return
+    if promote_nixpkgs(gh, nixpkgs_repo, nixpkgs_target_branch, integration_branch):
         fc_nixos_pr.create_issue_comment(
-            f"Rebased nixpkgs `{nixpkgs_target_branch}` branch successfully."
+            f"Promoted this nixpkgs integration branch to the `{nixpkgs_target_branch}` branch successfully."
         )
         cleanup_old_prs_and_branches(
             gh, integration_branch, fc_nixos_pr.base.ref

--- a/src/update_nixpkgs/update.py
+++ b/src/update_nixpkgs/update.py
@@ -92,7 +92,7 @@ def rebase_nixpkgs(
     integration_branch: str,
     last_day_integration_branch: str,
     force: bool,
-    matrix_hookshot: MatrixHookshot
+    matrix_hookshot: MatrixHookshot,
 ) -> NixpkgsRebaseResult | None:
     logging.info("Trying to rebase nixpkgs repository.")
     if nixpkgs_repo.is_dirty():
@@ -129,7 +129,8 @@ def rebase_nixpkgs(
             nixpkgs_repo.git.rebase(f"upstream/{branch_to_rebase}")
         except GitCommandError:
             logging.exception("nixpkgs rebase failed")
-            matrix_hookshot.send_notification(f"""\
+            matrix_hookshot.send_notification(
+                f"""\
 update-nixpkgs: ERROR nixpkgs rebase failed for {branch_to_rebase}. Please resolve the conflict manually with the following commands:
 
 ```
@@ -140,7 +141,8 @@ git checkout -b {integration_branch} origin/{branch_to_rebase}
 git rebase upstream/{branch_to_rebase}
 git push origin {integration_branch}
 ```
-""")
+"""
+            )
             sys.exit(1)
 
         # Check if there are new commits compared to the last day's integration branch.
@@ -252,7 +254,7 @@ def run(
     nixpkgs_dir: str,
     force: bool,
     github_access_token: str,
-    matrix_hookshot_url: str
+    matrix_hookshot_url: str,
 ):
     matrix_hookshot = MatrixHookshot(matrix_hookshot_url)
     today = datetime.date.today().isoformat()
@@ -287,7 +289,7 @@ def run(
             integration_branch,
             last_day_integration_branch,
             force,
-            matrix_hookshot
+            matrix_hookshot,
         ):
             logging.info(
                 f"Updated 'nixpkgs' to '{result.fork_after_rebase.hexsha}'"

--- a/src/update_nixpkgs/update.py
+++ b/src/update_nixpkgs/update.py
@@ -8,7 +8,6 @@ Workflow:
 * if new:
     * push to integration branch (nixpkgs-auto-update/fc-XX.XX-dev/YYYY-MM-DD)
     * update fc-nixos & create PR
-    * comment diff/changelog since last commit into PR
 On Merge (fc-nixos):
     * merge updated nixpkgs into nixos-XX.XX branch
     * delete old integration branches in nixpkgs and fc-nixos
@@ -35,7 +34,6 @@ from utils.matrix import MatrixHookshot
 NIXOS_VERSION_PATH = "release/nixos-version"
 PACKAGE_VERSIONS_PATH = "release/package-versions.json"
 VERSIONS_PATH = "release/versions.json"
-CHANGELOG_DIR = "changelog.d"
 
 
 @dataclass
@@ -201,24 +199,11 @@ def update_fc_nixos(
     check_output(["nix", "run", ".#buildVersionsJson"]).decode("utf-8")
     check_output(["nix", "run", ".#buildPackageVersionsJson"]).decode("utf-8")
 
-    changelog_path = (
-        Path(CHANGELOG_DIR)
-        / f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}_nixpkgs-auto-update-{target_branch}.md"
-    )
-    changelog_path.write_text(
-        f"""
-### NixOS XX.XX platform
-
-- Update nixpkgs from {previous_hex_sha} to {new_hex_sha}
-"""
-    )
-
     repo.git.add(
         [
             "flake.lock",
             VERSIONS_PATH,
             PACKAGE_VERSIONS_PATH,
-            str(changelog_path),
         ]
     )
     repo.git.commit(message=f"Auto update nixpkgs to {new_hex_sha}")

--- a/src/utils/matrix.py
+++ b/src/utils/matrix.py
@@ -1,0 +1,11 @@
+import requests
+
+
+class MatrixHookshot:
+    def __init__(self, hookshot_url):
+        self.hookshot_url = hookshot_url
+
+    def send_notification(self, message: str):
+        requests.put(self.hookshot_url, json={
+            "text": message
+        })

--- a/src/utils/matrix.py
+++ b/src/utils/matrix.py
@@ -6,6 +6,6 @@ class MatrixHookshot:
         self.hookshot_url = hookshot_url
 
     def send_notification(self, message: str):
-        requests.put(self.hookshot_url, json={
-            "text": message
-        }).raise_for_status()
+        requests.put(
+            self.hookshot_url, json={"text": message}
+        ).raise_for_status()

--- a/src/utils/matrix.py
+++ b/src/utils/matrix.py
@@ -8,4 +8,4 @@ class MatrixHookshot:
     def send_notification(self, message: str):
         requests.put(self.hookshot_url, json={
             "text": message
-        })
+        }).raise_for_status()


### PR DESCRIPTION
PL-133100


> [!NOTE]  
> * [x] Requires MATRIX_HOOKSHOT_URL in secrets (fc-nixos + fc-nixos-release-tools) to be set.

## Security considerations

- [x] [Security requirements](https://wiki.flyingcircus.io/System_Development_Guideline#Security_requirement_principles_and_testing) defined? (WHERE)
  - Should work in these scenarios:
    - Normal: No merge conflict, straight forward rebase
    - Conflict: Send notification, don't create PR
    - Moved nixpkgs while PR open: reject hard-rebase
- [x] Security requirements tested? (EVIDENCE)
  - Tested in fc-nixos-testing

