### PR TITLE
release: allow ignoring a release branch

### DIFF
--- a/src/release/__init__.py
+++ b/src/release/__init__.py
@@ -12,7 +12,7 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from . import state
-from .branch import Branch
+from .branch import Branch, Ignore
 from .command import Command, step
 from .doc import Doc, next_release_id
 from .git import FC_NIXOS
@@ -186,11 +186,12 @@ class Status(Command):
             table.add_column("Production commit ID")
             table.add_column("Hydra Eval")
             for branch in branches.values():
-                test_state = (
-                    "[green]tested[/green]"
-                    if branch.tested
-                    else "[red]untested[/red]"
-                )
+                if branch.tested:
+                    test_state = "[green]tested[/green]"
+                elif branch.ignored:
+                    test_state = "[grey69]ignored[/grey69]"
+                else:
+                    test_state = "[red]untested[/red]"
                 table.add_row(
                     branch.nixos_version,
                     test_state,
@@ -225,6 +226,13 @@ def main():
         help="Perform the release steps for this specific branch. E.g. `24.11`.",
     )
     branch_parser.set_defaults(command=Branch)
+
+    ignore_parser = subparser.add_parser("ignore")
+    ignore_parser.add_argument(
+        "nixos_version",
+        help="Do not create a release for this specific branch. E.g. `24.11`.",
+    )
+    ignore_parser.set_defaults(command=Ignore)
 
     doc_parser = subparser.add_parser("doc")
     doc_parser.set_defaults(command=Doc)

--- a/src/release/branch.py
+++ b/src/release/branch.py
@@ -326,3 +326,23 @@ class Branch(Command):
         """Mark the branch as [green]tested[/green]."""
         self.branch.tested = True
         print("All good, the release for this branch is now done.")
+
+
+class Ignore(Command):
+    def __init__(self, release: Release, nixos_version: str):
+        self.release = release
+        self.nixos_version = nixos_version
+
+    def __call__(self):
+        try:
+            branch = self.release.branches[self.nixos_version]
+        except KeyError:
+            print(
+                f"[red]'branch {self.nixos_version}' was not scheduled for release or is unknown"
+            )
+            raise RuntimeError()
+        else:
+            branch.ignored = True
+            print(
+                f"[cyan]Ignoring [bold]{self.nixos_version}[/bold] during this release cycle."
+            )

--- a/src/release/doc.py
+++ b/src/release/doc.py
@@ -96,11 +96,11 @@ def next_release_id(date: datetime.date) -> str:
 def collect_changelogs(release) -> MarkdownTree:
     changelog = MarkdownTree.from_sections(
         "Impact",
-        *(f"NixOS {k} platform" for k in sorted(release.branches)),
+        *(f"NixOS {k} platform" for k in sorted(release.work_branches)),
         "Documentation",
         "Detailed Changes",
     )
-    for _, branch in sorted(release.branches.items()):
+    for _, branch in sorted(release.work_branches.items()):
         frag = MarkdownTree.from_str(branch.changelog)
         frag["Impact"].add_header(branch.nixos_version)
         frag.rename(
@@ -145,13 +145,13 @@ class Doc(Command):
     @step(skip_seen=False)
     def docs(self):
         """Verify all branches are marked as tested"""
-        branches = list(self.release.branches)
+        branches = list(self.release.work_branches)
         print(
             "This will release the changelog for the following versions: "
             + ", ".join(branches)
         )
 
-        for branch in self.release.branches.values():
+        for branch in self.release.work_branches.values():
             if not branch.tested:
                 print(f"[red]'{branch.nixos_version}' is not tested")
                 raise RuntimeError()

--- a/src/release/state.py
+++ b/src/release/state.py
@@ -28,10 +28,16 @@ class Release(BaseModel):
     def release_num(self):
         return self.id.split("_", maxsplit=1)[1]
 
+    @property
+    def work_branches(self):
+        """Branches that are not to be ignored."""
+        return {k: v for (k, v) in self.branches.items() if not v.ignored}
+
 
 class Branch(BaseModel):
     nixos_version: str
     tested: bool = False
+    ignored: bool = False
     orig_staging_commit: str = ""
     new_production_commit: str = ""
     hydra_eval_id: str = ""


### PR DESCRIPTION
Not all auto-detected branches do always need to be taken into account for a release. One example is the 25.05 branch, which already has a production branch but yet has to be publicly released for customers.

Introduces the command `release ignore 25.05`.

Tested by doing this week's release with this code.