### PR TITLE
update_nixpkgs: drop 24.11

### DIFF
--- a/src/update_nixpkgs/__init__.py
+++ b/src/update_nixpkgs/__init__.py
@@ -6,7 +6,7 @@ from logging import INFO, basicConfig
 FC_NIXOS_REPO = "flyingcircusio/fc-nixos"
 NIXPKGS_REPO = "flyingcircusio/nixpkgs"
 # Mapping of platform version to nixos branch
-VERSIONS = {"24.11": "nixos-24.11", "25.05": "nixos-25.05"}
+VERSIONS = {"25.05": "nixos-25.05"}
 
 
 def main():


### PR DESCRIPTION
Upstream nixpkgs 24.11 won't receive any further updates. The auto-merge job can remain, as we might still do changes/ backports to fc-nixos 24.11.