### PR TITLE
release flow: reduce potential for race conditions

### DIFF
--- a/src/release/branch.py
+++ b/src/release/branch.py
@@ -237,7 +237,6 @@ class Branch(Command):
             # Check if this is specifically a non-fast-forward/diverged remote error
             diverged_remote_patterns = ["(non-fast-forward)", "(fetch first)"]
 
-            breakpoint()
             if not any(
                 pattern in e.cmd_out for pattern in diverged_remote_patterns
             ):

--- a/src/release/state.py
+++ b/src/release/state.py
@@ -9,8 +9,8 @@ STATE_FILE = Path("state.json")
 
 
 class Release(BaseModel):
-    id: str = None
-    date: datetime.date = None
+    id: str | None = None
+    date: datetime.date | None = None
     branches: dict[str, "Branch"] = {}
     steps: set = set()
 


### PR DESCRIPTION
When doing a release, the staging branch might be updated in the background, causing releasetest machines to adapt a revision even *more recent* than the expected staging revision.
To avoid this, let's reduce the time between retrieving the expected revision and the time we compare it at the VMs. Also, it suffices to have checked that revision once, and skip these check steps in subsequent runs.

Note: There are some further steps where I do not exactly see the need for `skip_seen=False`, but these have not yet turned out to be problematic in practice, so I leave these untouched.

Additionally contains two minor fixes.

PL-134031