### PR TITLE
release doc: remove default "Documentation" section

### DIFF
--- a/src/release/doc.py
+++ b/src/release/doc.py
@@ -97,7 +97,6 @@ def collect_changelogs(release) -> MarkdownTree:
     changelog = MarkdownTree.from_sections(
         "Impact",
         *(f"NixOS {k} platform" for k in sorted(release.work_branches)),
-        "Documentation",
         "Detailed Changes",
     )
     for _, branch in sorted(release.work_branches.items()):
@@ -115,7 +114,6 @@ def collect_changelogs(release) -> MarkdownTree:
                 )
             )
         changelog |= frag
-    changelog["Documentation"] += "<!--\nadd entries if necessary\n-->"
     changelog.move_to_end("Detailed Changes")
     changelog.add_header(f"Release {release.id} ({release.date.isoformat()})")
     changelog.entries.insert(


### PR DESCRIPTION
Speaking from experience I can say that this section is never used and only requires me to do an extra editing step during the release process. Documentation changes are not necessarily rolled out in sync with platform releases, and even when they are there is no process in place to review, discover, and collect these relevant doc changes.

If such information ever needs to be added, such a section may just be added manually again.